### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,14 @@
 # Welcome!
 
-We're so glad you're thinking about contributing to a TTS open source project! If you're unsure about anything, just ask -- or submit the issue or pull request anyway. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
-
-We want to ensure a welcoming environment for all of our projects. Our staff follow the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md) and all contributors should do the same.
+We're so glad you're thinking about contributing to a [Federal Government open source project](https://code.gov/)! If you're unsure about anything, just ask -- or submit the issue or pull request anyway. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
 
 We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md).
 
-If you have any questions or want to read more, check out the [18F Open Source Policy GitHub repository](https://github.com/18f/open-source-policy), or just [shoot us an email](mailto:18f@gsa.gov).
+## Policies
+
+We want to ensure a welcoming environment for all of our projects. Our staff follow the [TTS Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md) and all contributors should do the same.
+
+We adhere to the [18F Open Source Policy](https://github.com/18f/open-source-policy). If you have any questions, just [shoot us an email](mailto:18f@gsa.gov).
 
 ## Public domain
 


### PR DESCRIPTION
* Changed `TTS Open Source project` to a `Federal Government open source project`, linking to code.gov as well. The idea is we can promote all Federal Government open source projects as well as our own code.gov project.
* Changed `18F Code of Conduct` to `TTS Code of Conduct` to update the actual name of the repo/policy.
* Created a `Policies` section, while moving up the internal-to-the-repo files to the initial paragraph.
* Within the `Policies` section, updated the sentence referencing the 18F Open Source Policy.